### PR TITLE
Add TestUtil class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,24 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
 			</plugin>
 

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -27,11 +27,6 @@ public final class TestUtil {
 		return new SutState( Arrays.asList( rootElements ) );
 	}
 
-	public static IdentifyingAttributes getIdentifyingAttributes( final String id ) {
-		return new IdentifyingAttributes( Arrays.asList( new StringAttribute( "a", id ), new StringAttribute( "b", id ),
-				new StringAttribute( "c", id ) ) );
-	}
-
 	/**
 	 * Creates a new root element identified by a user-defined ID. Root elements with the same ID and number of children
 	 * should be equal.
@@ -58,7 +53,12 @@ public final class TestUtil {
 		return rootElement;
 	}
 
-	public static Element getElement( final Element parent, final int index ) {
+	private static IdentifyingAttributes getIdentifyingAttributes( final String id ) {
+		return new IdentifyingAttributes( Arrays.asList( new StringAttribute( "a", id ), new StringAttribute( "b", id ),
+				new StringAttribute( "c", id ) ) );
+	}
+
+	private static Element getElement( final Element parent, final int index ) {
 		return Element.create( "retestId", parent, getIdentifyingAttributes( "child" + index ), new Attributes(),
 				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ) );
 	}

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -28,8 +28,8 @@ public final class TestUtil {
 	}
 
 	/**
-	 * Creates a new root element identified by a user-defined ID. Root elements with the same ID and number of children
-	 * should be equal.
+	 * Creates a new root element using the given identifying attributes value and number of child elements. Other root
+	 * elements with the same identifying attributes value and number of children should be equal.
 	 *
 	 * @param identifyingAttributesValue
 	 * 		Used as an identifying attributes value to ensure equality as long as the number of children is the same.

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -20,7 +20,7 @@ public final class TestUtil {
 	 * Creates a new SutState which is equal to another SutState if they contain equal collections of root elements.
 	 *
 	 * @param rootElements
-	 *            The collection of root elements of the SutState.
+	 * 		The collection of root elements of the SutState.
 	 * @return A new SutState.
 	 */
 	public static SutState createSutState( final RootElement... rootElements ) {
@@ -31,16 +31,19 @@ public final class TestUtil {
 	 * Creates a new root element identified by a user-defined ID. Root elements with the same ID and number of children
 	 * should be equal.
 	 *
-	 * @param id
-	 *            The ID which uniquely identifies the root element as long as the number of children is the same.
+	 * @param identifyingAttributesValue
+	 * 		Used as an identifying attributes value to ensure equality as long as the number of children is the same.
 	 * @param numberOfChildren
-	 *            The number of contained components of the root element.
+	 * 		The number of contained components of the root element.
 	 * @return A new root element.
 	 */
-	public static RootElement getRootElement( final String id, final int numberOfChildren ) {
-		final RootElement rootElement = new RootElement( "retestId", getIdentifyingAttributes( id ), new Attributes(),
-				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0", 0,
-				"My Window" );
+	public static RootElement getRootElement( final String identifyingAttributesValue, final int numberOfChildren ) {
+		final RootElement rootElement =
+				new RootElement( "retestId", getIdentifyingAttributes( identifyingAttributesValue ),
+						new Attributes(),
+						new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0",
+						0,
+						"My Window" );
 		if ( numberOfChildren > 0 ) {
 			final List<Element> children = new ArrayList<>();
 
@@ -53,9 +56,10 @@ public final class TestUtil {
 		return rootElement;
 	}
 
-	private static IdentifyingAttributes getIdentifyingAttributes( final String id ) {
-		return new IdentifyingAttributes( Arrays.asList( new StringAttribute( "a", id ), new StringAttribute( "b", id ),
-				new StringAttribute( "c", id ) ) );
+	private static IdentifyingAttributes getIdentifyingAttributes( final String identifyingAttributesValue ) {
+		return new IdentifyingAttributes( Arrays.asList( new StringAttribute( "a", identifyingAttributesValue ),
+				new StringAttribute( "b", identifyingAttributesValue ),
+				new StringAttribute( "c", identifyingAttributesValue ) ) );
 	}
 
 	private static Element getElement( final Element parent, final int index ) {

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -14,12 +14,13 @@ import de.retest.recheck.ui.image.Screenshot;
 
 public final class TestUtil {
 
-	private TestUtil() { }
+	private TestUtil() {}
 
 	/**
 	 * Creates a new SutState which is equal to another SutState if they contain equal collections of root elements.
 	 *
-	 * @param rootElements The collection of root elements of the SutState.
+	 * @param rootElements
+	 *            The collection of root elements of the SutState.
 	 * @return A new SutState.
 	 */
 	public static SutState createSutState( final RootElement... rootElements ) {
@@ -35,15 +36,15 @@ public final class TestUtil {
 	 * Creates a new root element identified by a user-defined ID. Root elements with the same ID and number of children
 	 * should be equal.
 	 *
-	 * @param id               The ID which uniquely identifies the root element as long as the number of children is
-	 *                         the same.
-	 * @param numberOfChildren The number of contained components of the root element.
+	 * @param id
+	 *            The ID which uniquely identifies the root element as long as the number of children is the same.
+	 * @param numberOfChildren
+	 *            The number of contained components of the root element.
 	 * @return A new root element.
 	 */
 	public static RootElement getRootElement( final String id, final int numberOfChildren ) {
 		final RootElement rootElement = new RootElement( "retestId", getIdentifyingAttributes( id ), new Attributes(),
-				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0",
-				0,
+				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0", 0,
 				"My Window" );
 		if ( numberOfChildren > 0 ) {
 			final List<Element> children = new ArrayList<>();
@@ -58,7 +59,7 @@ public final class TestUtil {
 	}
 
 	public static Element getElement( final Element parent, final int index ) {
-		return Element.create( "retestId", parent, getIdentifyingAttributes( "child" + index ),
-				new Attributes(), new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ) );
+		return Element.create( "retestId", parent, getIdentifyingAttributes( "child" + index ), new Attributes(),
+				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ) );
 	}
 }

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -1,0 +1,64 @@
+package de.retest.surili.commons.test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.StringAttribute;
+import de.retest.recheck.ui.descriptors.SutState;
+import de.retest.recheck.ui.image.Screenshot;
+
+public final class TestUtil {
+
+	private TestUtil() { }
+
+	/**
+	 * Creates a new SutState which is equal to another SutState if they contain equal collections of root elements.
+	 *
+	 * @param rootElements The collection of root elements of the SutState.
+	 * @return A new SutState.
+	 */
+	public static SutState createSutState( final RootElement... rootElements ) {
+		return new SutState( Arrays.asList( rootElements ) );
+	}
+
+	public static IdentifyingAttributes getIdentifyingAttributes( final String id ) {
+		return new IdentifyingAttributes( Arrays.asList( new StringAttribute( "a", id ), new StringAttribute( "b", id ),
+				new StringAttribute( "c", id ) ) );
+	}
+
+	/**
+	 * Creates a new root element identified by a user-defined ID. Root elements with the same ID and number of children
+	 * should be equal.
+	 *
+	 * @param id               The ID which uniquely identifies the root element as long as the number of children is
+	 *                         the same.
+	 * @param numberOfChildren The number of contained components of the root element.
+	 * @return A new root element.
+	 */
+	public static RootElement getRootElement( final String id, final int numberOfChildren ) {
+		final RootElement rootElement = new RootElement( "retestId", getIdentifyingAttributes( id ), new Attributes(),
+				new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0",
+				0,
+				"My Window" );
+		if ( numberOfChildren > 0 ) {
+			final List<Element> children = new ArrayList<>();
+
+			for ( int i = 0; i < numberOfChildren; i++ ) {
+				children.add( getElement( rootElement, i ) );
+			}
+			rootElement.addChildren( children );
+		}
+
+		return rootElement;
+	}
+
+	public static Element getElement( final Element parent, final int index ) {
+		return Element.create( "retestId", parent, getIdentifyingAttributes( "child" + index ),
+				new Attributes(), new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ) );
+	}
+}

--- a/src/main/java/de/retest/surili/commons/test/TestUtil.java
+++ b/src/main/java/de/retest/surili/commons/test/TestUtil.java
@@ -20,7 +20,7 @@ public final class TestUtil {
 	 * Creates a new SutState which is equal to another SutState if they contain equal collections of root elements.
 	 *
 	 * @param rootElements
-	 * 		The collection of root elements of the SutState.
+	 *            The collection of root elements of the SutState.
 	 * @return A new SutState.
 	 */
 	public static SutState createSutState( final RootElement... rootElements ) {
@@ -32,17 +32,16 @@ public final class TestUtil {
 	 * elements with the same identifying attributes value and number of children should be equal.
 	 *
 	 * @param identifyingAttributesValue
-	 * 		Used as an identifying attributes value to ensure equality as long as the number of children is the same.
+	 *            Used as an identifying attributes value to ensure equality as long as the number of children is the
+	 *            same.
 	 * @param numberOfChildren
-	 * 		The number of contained components of the root element.
+	 *            The number of contained components of the root element.
 	 * @return A new root element.
 	 */
 	public static RootElement getRootElement( final String identifyingAttributesValue, final int numberOfChildren ) {
 		final RootElement rootElement =
-				new RootElement( "retestId", getIdentifyingAttributes( identifyingAttributesValue ),
-						new Attributes(),
-						new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0",
-						0,
+				new RootElement( "retestId", getIdentifyingAttributes( identifyingAttributesValue ), new Attributes(),
+						new Screenshot( "prefix", new byte[] { 1, 2, 3 }, Screenshot.ImageType.PNG ), "screen0", 0,
 						"My Window" );
 		if ( numberOfChildren > 0 ) {
 			final List<Element> children = new ArrayList<>();

--- a/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
+++ b/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
@@ -20,8 +20,11 @@ class TestUtilTest {
 		final RootElement rootElement0 = TestUtil.getRootElement( "foo", numberOfChildren );
 		final RootElement rootElement1 = TestUtil.getRootElement( "foo", numberOfChildren );
 
-		final List<Element> containedElements = rootElement.getContainedElements();
-		assertThat( containedElements ).hasSize( numberOfChildren );
+		final List<Element> containedElements0 = rootElement0.getContainedElements();
+		assertThat( containedElements0 ).hasSize( numberOfChildren );
+
+		final List<Element> containedElements1 = rootElement1.getContainedElements();
+		assertThat( containedElements1 ).hasSize( numberOfChildren );
 
 		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
 		final SutState sutState1 = TestUtil.createSutState( rootElement1 );
@@ -36,8 +39,11 @@ class TestUtilTest {
 		final RootElement rootElement0 = TestUtil.getRootElement( "foo", numberOfChildren );
 		final RootElement rootElement1 = TestUtil.getRootElement( "bar", numberOfChildren );
 
-		final List<Element> containedElements = rootElement.getContainedElements();
-		assertThat( containedElements ).hasSize( numberOfChildren );
+		final List<Element> containedElements0 = rootElement0.getContainedElements();
+		assertThat( containedElements0 ).hasSize( numberOfChildren );
+
+		final List<Element> containedElements1 = rootElement1.getContainedElements();
+		assertThat( containedElements1 ).hasSize( numberOfChildren );
 
 		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
 		final SutState sutState1 = TestUtil.createSutState( rootElement1 );

--- a/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
+++ b/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
@@ -1,7 +1,6 @@
 package de.retest.surili.commons.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
@@ -9,57 +8,40 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.ui.descriptors.Element;
-import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
 
 class TestUtilTest {
 
 	@Test
-	void created_sut_state_should_contain_given_root_elements() throws Exception {
-		final RootElement re0 = mock( RootElement.class );
-		final RootElement re1 = mock( RootElement.class );
-
-		final SutState sutState = TestUtil.createSutState( re0, re1 );
-
-		assertThat( sutState.getRootElements() ).containsExactly( re0, re1 );
-	}
-
-	@Test
-	void created_identifying_attributes_should_TODO() throws Exception {
-		final String id = "foo";
-
-		final IdentifyingAttributes identifyingAttributes = TestUtil.getIdentifyingAttributes( id );
-
-		// TODO Add assertion and adapt test case name.
-		fail();
-	}
-
-	@Test
-	void created_root_element_should_TODO() throws Exception {
-		final String id = "foo";
+	void created_sut_states_elements_should_be_equal() throws Exception {
 		final int numberOfChildren = 3;
 
-		final RootElement rootElement = TestUtil.getRootElement( id, numberOfChildren );
+		final RootElement rootElement0 = TestUtil.getRootElement( "foo", numberOfChildren );
+		final RootElement rootElement1 = TestUtil.getRootElement( "foo", numberOfChildren );
 
 		final List<Element> containedElements = rootElement.getContainedElements();
 		assertThat( containedElements ).hasSize( numberOfChildren );
 
-		// TODO Add assertion and adapt test case name.
-		fail();
+		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
+		final SutState sutState1 = TestUtil.createSutState( rootElement1 );
+
+		assertThat( sutState0, equalTo( sutState1 ) );
 	}
 
 	@Test
-	void created_element_should_TODO() throws Exception {
-		final Element parent = mock( Element.class );
-		final int index = 1;
+	void created_sut_states_should_not_be_equal() throws Exception {
+		final int numberOfChildren = 3;
 
-		final Element element = TestUtil.getElement( parent, index );
+		final RootElement rootElement0 = TestUtil.getRootElement( "foo", numberOfChildren );
+		final RootElement rootElement1 = TestUtil.getRootElement( "bar", numberOfChildren );
 
-		assertThat( element.getParent() ).isEqualTo( parent );
+		final List<Element> containedElements = rootElement.getContainedElements();
+		assertThat( containedElements ).hasSize( numberOfChildren );
 
-		// TODO Add assertion and adapt test case name.
-		fail();
+		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
+		final SutState sutState1 = TestUtil.createSutState( rootElement1 );
+
+		assertThat( sutState0, not( equalTo( sutState1 ) ) );
 	}
-
 }

--- a/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
+++ b/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
@@ -1,0 +1,65 @@
+package de.retest.surili.commons.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.SutState;
+
+class TestUtilTest {
+
+	@Test
+	void created_sut_state_should_contain_given_root_elements() throws Exception {
+		final RootElement re0 = mock( RootElement.class );
+		final RootElement re1 = mock( RootElement.class );
+
+		final SutState sutState = TestUtil.createSutState( re0, re1 );
+
+		assertThat( sutState.getRootElements() ).containsExactly( re0, re1 );
+	}
+
+	@Test
+	void created_identifying_attributes_should_TODO() throws Exception {
+		final String id = "foo";
+
+		final IdentifyingAttributes identifyingAttributes = TestUtil.getIdentifyingAttributes( id );
+
+		// TODO Add assertion and adapt test case name.
+		fail();
+	}
+
+	@Test
+	void created_root_element_should_TODO() throws Exception {
+		final String id = "foo";
+		final int numberOfChildren = 3;
+
+		final RootElement rootElement = TestUtil.getRootElement( id, numberOfChildren );
+
+		final List<Element> containedElements = rootElement.getContainedElements();
+		assertThat( containedElements ).hasSize( numberOfChildren );
+
+		// TODO Add assertion and adapt test case name.
+		fail();
+	}
+
+	@Test
+	void created_element_should_TODO() throws Exception {
+		final Element parent = mock( Element.class );
+		final int index = 1;
+
+		final Element element = TestUtil.getElement( parent, index );
+
+		assertThat( element.getParent() ).isEqualTo( parent );
+
+		// TODO Add assertion and adapt test case name.
+		fail();
+	}
+
+}

--- a/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
+++ b/src/test/java/de/retest/surili/commons/test/TestUtilTest.java
@@ -1,7 +1,6 @@
 package de.retest.surili.commons.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
@@ -29,7 +28,7 @@ class TestUtilTest {
 		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
 		final SutState sutState1 = TestUtil.createSutState( rootElement1 );
 
-		assertThat( sutState0, equalTo( sutState1 ) );
+		assertThat( sutState0 ).isEqualTo( sutState1 );
 	}
 
 	@Test
@@ -48,6 +47,6 @@ class TestUtilTest {
 		final SutState sutState0 = TestUtil.createSutState( rootElement0 );
 		final SutState sutState1 = TestUtil.createSutState( rootElement1 );
 
-		assertThat( sutState0, not( equalTo( sutState1 ) ) );
+		assertThat( sutState0 ).isNotEqualTo( sutState1 );
 	}
 }


### PR DESCRIPTION
Provides methods for writing unit tests which are used by surili and
gui-state-machine-api.

Note: This was previously part of the action-selection-strategy branch but since commons was moved, I have added this pull request. I will use it in the gui-state-machine-api project, too.