### PR TITLE
Add stringifiers for core classes (suites, tests, actions)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<project.resources.sourceEncoding>${encoding}</project.resources.sourceEncoding>
 		<project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<maven.surefire.version>2.22.2</maven.surefire.version>
+		<maven.surefire.and.failsafe.version>2.22.2</maven.surefire.and.failsafe.version>
 		<maven.javadoc.and.source.version>3.1.0</maven.javadoc.and.source.version>
 	</properties>
 
@@ -110,7 +110,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>${maven.surefire.version}</version>
+				<version>${maven.surefire.and.failsafe.version}</version>
 				<configuration>
 					<properties>
 						<configurationParameters>
@@ -119,6 +119,27 @@
 						</configurationParameters>
 					</properties>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven.surefire.and.failsafe.version}</version>
+				<configuration>
+					<skipTests>${skipTests}</skipTests>
+					<skipITs>${skipITs}</skipITs>
+					<!-- see https://stackoverflow.com/a/15567782 -->
+					<reportsDirectory>${project.build.directory}/surefire-reports/</reportsDirectory>
+				</configuration>
+				<executions>
+					<execution>
+						<id>run-integration-tests</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>

--- a/src/main/java/de/retest/surili/commons/stringify/ActionStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/ActionStringifier.java
@@ -1,20 +1,22 @@
 package de.retest.surili.commons.stringify;
 
 import de.retest.surili.commons.actions.Action;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class ActionStringifier implements Stringifier<Action> {
 
-	private final int indentationLevel;
+	private final String prefix;
 
 	public ActionStringifier() {
 		this( 0 );
 	}
 
+	public ActionStringifier( final int indentationLevel ) {
+		prefix = Tabs.of( indentationLevel );
+	}
+
 	@Override
 	public String toString( final Action action ) {
-		return Tabs.of( indentationLevel ) + action.toString();
+		return prefix + action.toString();
 	}
 
 }

--- a/src/main/java/de/retest/surili/commons/stringify/ActionStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/ActionStringifier.java
@@ -1,0 +1,20 @@
+package de.retest.surili.commons.stringify;
+
+import de.retest.surili.commons.actions.Action;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ActionStringifier implements Stringifier<Action> {
+
+	private final int indentationLevel;
+
+	public ActionStringifier() {
+		this( 0 );
+	}
+
+	@Override
+	public String toString( final Action action ) {
+		return Tabs.of( indentationLevel ) + action.toString();
+	}
+
+}

--- a/src/main/java/de/retest/surili/commons/stringify/Stringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/Stringifier.java
@@ -1,0 +1,21 @@
+package de.retest.surili.commons.stringify;
+
+import java.util.Collections;
+
+@FunctionalInterface
+public interface Stringifier<T> {
+
+	static class Tabs {
+
+		static String of( final int indentationLevel ) {
+			if ( indentationLevel == 0 ) {
+				return "";
+			}
+			return String.join( "", Collections.nCopies( indentationLevel, "\t" ) );
+		}
+
+	}
+
+	String toString( T object );
+
+}

--- a/src/main/java/de/retest/surili/commons/stringify/TestCaseStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/TestCaseStringifier.java
@@ -1,0 +1,35 @@
+package de.retest.surili.commons.stringify;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import de.retest.surili.commons.actions.Action;
+import de.retest.surili.commons.core.TestCase;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TestCaseStringifier implements Stringifier<TestCase> {
+
+	private final int indentationLevel;
+	private final ActionStringifier actionStringifier;
+
+	public TestCaseStringifier() {
+		this( 0 );
+	}
+
+	public TestCaseStringifier( final int indentationLevel ) {
+		this( indentationLevel, new ActionStringifier( indentationLevel + 1 ) );
+	}
+
+	@Override
+	public String toString( final TestCase testCase ) {
+		final List<Action> actions = testCase.getActions();
+		if ( actions.isEmpty() ) {
+			return "TestCase: empty";
+		}
+		return Tabs.of( indentationLevel ) + "TestCase:\n" + actions.stream() //
+				.map( actionStringifier::toString ) //
+				.collect( Collectors.joining( "\n" ) );
+	}
+
+}

--- a/src/main/java/de/retest/surili/commons/stringify/TestCaseStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/TestCaseStringifier.java
@@ -5,12 +5,10 @@ import java.util.stream.Collectors;
 
 import de.retest.surili.commons.actions.Action;
 import de.retest.surili.commons.core.TestCase;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class TestCaseStringifier implements Stringifier<TestCase> {
 
-	private final int indentationLevel;
+	private final String prefix;
 	private final ActionStringifier actionStringifier;
 
 	public TestCaseStringifier() {
@@ -21,13 +19,18 @@ public class TestCaseStringifier implements Stringifier<TestCase> {
 		this( indentationLevel, new ActionStringifier( indentationLevel + 1 ) );
 	}
 
+	public TestCaseStringifier( final int indentationLevel, final ActionStringifier actionStringifier ) {
+		prefix = Tabs.of( indentationLevel ) + "TestCase:";
+		this.actionStringifier = actionStringifier;
+	}
+
 	@Override
 	public String toString( final TestCase testCase ) {
 		final List<Action> actions = testCase.getActions();
 		if ( actions.isEmpty() ) {
-			return "TestCase: empty";
+			return prefix + " empty";
 		}
-		return Tabs.of( indentationLevel ) + "TestCase:\n" + actions.stream() //
+		return prefix + "\n" + actions.stream() //
 				.map( actionStringifier::toString ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/main/java/de/retest/surili/commons/stringify/TestSuiteStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/TestSuiteStringifier.java
@@ -1,0 +1,35 @@
+package de.retest.surili.commons.stringify;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import de.retest.surili.commons.core.TestCase;
+import de.retest.surili.commons.core.TestSuite;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TestSuiteStringifier implements Stringifier<TestSuite> {
+
+	private final int indentationLevel;
+	private final TestCaseStringifier testCaseStringifier;
+
+	public TestSuiteStringifier() {
+		this( 0 );
+	}
+
+	public TestSuiteStringifier( final int indentationLevel ) {
+		this( indentationLevel, new TestCaseStringifier( indentationLevel + 1 ) );
+	}
+
+	@Override
+	public String toString( final TestSuite testSuite ) {
+		final Set<? extends TestCase> testCases = testSuite.getTestCases();
+		if ( testCases.isEmpty() ) {
+			return "TestSuite: empty";
+		}
+		return Tabs.of( indentationLevel ) + "TestSuite:\n" + testCases.stream() //
+				.map( testCaseStringifier::toString ) //
+				.collect( Collectors.joining( "\n" ) );
+	}
+
+}

--- a/src/main/java/de/retest/surili/commons/stringify/TestSuiteStringifier.java
+++ b/src/main/java/de/retest/surili/commons/stringify/TestSuiteStringifier.java
@@ -5,12 +5,10 @@ import java.util.stream.Collectors;
 
 import de.retest.surili.commons.core.TestCase;
 import de.retest.surili.commons.core.TestSuite;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 public class TestSuiteStringifier implements Stringifier<TestSuite> {
 
-	private final int indentationLevel;
+	private final String prefix;
 	private final TestCaseStringifier testCaseStringifier;
 
 	public TestSuiteStringifier() {
@@ -21,13 +19,18 @@ public class TestSuiteStringifier implements Stringifier<TestSuite> {
 		this( indentationLevel, new TestCaseStringifier( indentationLevel + 1 ) );
 	}
 
+	public TestSuiteStringifier( final int indentationLevel, final TestCaseStringifier testCaseStringifier ) {
+		prefix = Tabs.of( indentationLevel ) + "TestSuite:";
+		this.testCaseStringifier = testCaseStringifier;
+	}
+
 	@Override
 	public String toString( final TestSuite testSuite ) {
 		final Set<? extends TestCase> testCases = testSuite.getTestCases();
 		if ( testCases.isEmpty() ) {
-			return "TestSuite: empty";
+			return prefix + " empty";
 		}
-		return Tabs.of( indentationLevel ) + "TestSuite:\n" + testCases.stream() //
+		return prefix + "\n" + testCases.stream() //
 				.map( testCaseStringifier::toString ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.java
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.java
@@ -1,0 +1,84 @@
+package de.retest.surili.commons.stringify;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.retest.surili.commons.actions.Action;
+import de.retest.surili.commons.actions.NavigateBackAction;
+import de.retest.surili.commons.actions.NavigateForwardAction;
+import de.retest.surili.commons.core.TestCase;
+import de.retest.surili.commons.core.TestCaseImpl;
+import de.retest.surili.commons.core.TestSuite;
+import de.retest.surili.commons.core.TestSuiteImpl;
+
+class StringifiersIT {
+
+	Action action;
+	TestCase testCase;
+	TestSuite testSuite;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		action = new NavigateForwardAction();
+		final Action otherAction = new NavigateBackAction();
+
+		testCase = new TestCaseImpl( Arrays.asList( action, otherAction ) );
+		final TestCase otherTestCase = new TestCaseImpl( Arrays.asList( otherAction, action ) );
+
+		final Set<TestCase> testCases = new LinkedHashSet<>( Arrays.asList( testCase, otherTestCase ) );
+
+		testSuite = new TestSuiteImpl( testCases );
+	}
+
+	@Test
+	void should_handle_actions() throws Exception {
+		final Stringifier<Action> cut = new ActionStringifier();
+
+		final String stringified = cut.toString( action );
+
+		Approvals.verify( stringified );
+	}
+
+	@Test
+	void should_handle_test_cases() throws Exception {
+		final Stringifier<TestCase> cut = new TestCaseStringifier();
+
+		final String stringified = cut.toString( testCase );
+
+		Approvals.verify( stringified );
+	}
+
+	@Test
+	void should_handle_test_suites() throws Exception {
+		final Stringifier<TestSuite> cut = new TestSuiteStringifier();
+
+		final String stringified = cut.toString( testSuite );
+
+		Approvals.verify( stringified );
+	}
+
+	@Test
+	void should_handle_empty_test_cases() throws Exception {
+		final Stringifier<TestCase> cut = new TestCaseStringifier();
+
+		final String stringified = cut.toString( new TestCaseImpl( Collections.emptyList() ) );
+
+		Approvals.verify( stringified );
+	}
+
+	@Test
+	void should_handle_empty_test_suites() throws Exception {
+		final Stringifier<TestSuite> cut = new TestSuiteStringifier();
+
+		final String stringified = cut.toString( new TestSuiteImpl( Collections.emptySet() ) );
+
+		Approvals.verify( stringified );
+	}
+
+}

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.java
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.java
@@ -81,4 +81,16 @@ class StringifiersIT {
 		Approvals.verify( stringified );
 	}
 
+	@Test
+	void should_handle_empty_test_suites_with_empty_test_cases() throws Exception {
+		final TestCase emptyTestCase = new TestCaseImpl( Collections.emptyList() );
+		final Set<TestCase> testCases = new LinkedHashSet<>( Arrays.asList( testCase, emptyTestCase ) );
+		final TestSuite testSuite = new TestSuiteImpl( testCases );
+		final Stringifier<TestSuite> cut = new TestSuiteStringifier();
+
+		final String stringified = cut.toString( testSuite );
+
+		Approvals.verify( stringified );
+	}
+
 }

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_actions.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_actions.approved.txt
@@ -1,0 +1,1 @@
+NavigateForwardAction()

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_cases.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_cases.approved.txt
@@ -1,0 +1,1 @@
+TestCase: empty

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_suites.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_suites.approved.txt
@@ -1,0 +1,1 @@
+TestSuite: empty

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_suites_with_empty_test_cases.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_empty_test_suites_with_empty_test_cases.approved.txt
@@ -1,0 +1,5 @@
+TestSuite:
+	TestCase:
+		NavigateForwardAction()
+		NavigateBackAction()
+	TestCase: empty

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_test_cases.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_test_cases.approved.txt
@@ -1,0 +1,3 @@
+TestCase:
+	NavigateForwardAction()
+	NavigateBackAction()

--- a/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_test_suites.approved.txt
+++ b/src/test/java/de/retest/surili/commons/stringify/StringifiersIT.should_handle_test_suites.approved.txt
@@ -1,0 +1,7 @@
+TestSuite:
+	TestCase:
+		NavigateForwardAction()
+		NavigateBackAction()
+	TestCase:
+		NavigateBackAction()
+		NavigateForwardAction()


### PR DESCRIPTION
Since you did the printers in recheck, I thought you may have some experience here and can provide valuable input. The stringifiers do essentially the same.