### PR TITLE
Fix missing coverage for SonarCloud

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -10,7 +10,7 @@ wget --quiet https://github.com/sormuras/bach/raw/master/install-jdk.sh && . ./i
 
 # disable SonarCloud for external PRs
 if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
-    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test verify sonar:sonar
+    ${MVN} verify sonar:sonar -Pcoverage
 else
-    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test verify
+    ${MVN} verify
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -222,4 +222,33 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>coverage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+						<version>0.8.5</version>
+						<executions>
+							<execution>
+								<id>prepare-agent</id>
+								<goals>
+									<goal>prepare-agent</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>report</id>
+								<goals>
+									<goal>report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Seems to work:

https://sonarcloud.io/dashboard?branch=fix%2Fsonarcloud-coverage&id=de.retest%3Asurili-commons

If coverage is back on `master` afterwards, I will adapt the remaining repos accordingly.

See also:

* https://community.sonarsource.com/t/sonarcloud-java-coverage-suddenly-zero-as-of-today/18410
* https://github.com/SonarSource/sq-com_example_java-maven-travis